### PR TITLE
Fixes bug in density calculation

### DIFF
--- a/LipidDyn/core.py
+++ b/LipidDyn/core.py
@@ -322,7 +322,6 @@ class Density:
                 # x coordinate of the atom divided by the x dimension of box
                 # find the fraction of box the atom is in on X
                 # divide by ten the coordinates to convert in nm
-           
                 m1 = (atom.position[0]*0.1)/(ts.dimensions[0]*0.1) 
                 if  m1 >= 1 : 
                     m1 -= 1 # pbc maybe subtracting 1 
@@ -331,7 +330,7 @@ class Density:
                 m2 = (atom.position[1]*0.1)/(ts.dimensions[1]*0.1)
                 if  m2 >= 1 : 
                     m2 -= 1 # pbc maybe subtracting 1 
-                if m1 < 0 : 
+                if m2 < 0 :
                     m2 +=1
                 
                 grid[int(m1*self.n1)][int(m2*self.n2)] +=  invcellvol  


### PR DESCRIPTION
Fixes #16

Note that we are still not perfectly consistent with GROMACS, there are differences in a few of elements:

```
E    Mismatched elements: 72 / 239121 (0.0301%)
E    Max absolute difference: 5.02924
E    Max relative difference: 1.00174321
```

When this happens, it's because we have atoms falling in an adjacent bin respect to what happens in GROMACS (so you see the density is -something in one bin and +something in an adjacent bin). I think this just depends on small numeric differences, I don't think it's worth investigating further (but let me know if you think it is @SimoneScrima @MatteoLambrughi @elenapapaleo )
