### PR TITLE
Removed default empty folders creation for fatslim raw data

### DIFF
--- a/bin/LipidDyn
+++ b/bin/LipidDyn
@@ -102,8 +102,7 @@ def module_fatslim(trajectory_file,
     if not os.path.exists(analysis_fatlism):
         try:
             os.mkdir((analysis_fatlism))
-            os.mkdir((analysis_fatlism +'/fatslim_apl'))
-            os.mkdir((analysis_fatlism + '/fatslim_thickness'))
+
         except OSError as exc:
             if exc.errno != errno.EEXIST:
                 raise
@@ -122,6 +121,18 @@ def module_fatslim(trajectory_file,
     if raw : # if the user required the raw data
         step = 4
         pbar.update((1/step)*100) # current step/total steps * 100
+        
+        fatslim_apl = os.path.abspath(os.path.join(analysis_fatlism, 'fatslim_apl'))
+        fatslim_thickness = os.path.abspath(os.path.join(analysis_fatlism, 'fatslim_thickness'))
+
+        if not os.path.exists(fatslim_apl) or not os.path.exists(fatslim_thickness):
+            try: 
+                os.mkdir((analysis_fatlism +'/fatslim_apl'))
+                os.mkdir((analysis_fatlism + '/fatslim_thickness'))
+            except OSError as exc:
+                if exc.errno != errno.EEXIST:
+                    raise
+
         fatslim.raw_AreaPerLipid(out_file = analysis_fatlism +
                                  '/fatslim_apl/raw_apl.csv')
 


### PR DESCRIPTION
Folder for raw data will be created only in the case the -raw flag is specified. If the folders already exist (i.e. from a previous run) the raw data files will be backed up as done for apl and thickness .xvg files 