### PR TITLE
87 enrichment and membrane only simulations

### DIFF
--- a/bin/LipidDyn
+++ b/bin/LipidDyn
@@ -870,18 +870,22 @@ def main():
                            out_dir)
             logging.info("--------------------------------------")
 
-        if args.enrichment and args.prot:
-            # add enrichment analysis with a protein
-            # do it if there is also the flag for the
-            # prot
-            logging.info("Analysis: Enrichment Analysis")
-            module_enrichment(u,
-                              leaflets,
-                              dict_selection,
-                              ncore,
-                              out_dir)
-            logging.info("--------------------------------------")
-
+        if args.enrichment :
+        
+            if args.prot :
+                # add enrichment analysis with a protein
+                # do it if there is also the flag for the
+                # prot
+                logging.info("Analysis: Enrichment Analysis")
+                module_enrichment(u,
+                                  leaflets,
+                                  dict_selection,
+                                  ncore,
+                                  out_dir)
+                logging.info("--------------------------------------")
+            
+            else :
+                logging.error("Enrichment can only be performed on simulations with proteins embedded in the membrane")
 
         if args.mod_mov :
 

--- a/bin/LipidDyn
+++ b/bin/LipidDyn
@@ -886,7 +886,8 @@ def main():
             
             else :
                 logging.error("Enrichment can only be performed on simulations with proteins embedded in the membrane")
-
+                logging.info("--------------------------------------")
+    
         if args.mod_mov :
 
             logging.info("Analysis: Diffusion movements")


### PR DESCRIPTION
I splittet the if statement up into two arguments.

I added the wanted error code. The log will now look like this when we are analysing a membrane with no embedded protein for enrichment:
![image](https://user-images.githubusercontent.com/101550001/198345537-4107408e-adc0-48c1-b188-4034a73394f7.png)

If other analyses are listed in the arguments it will still move on and complete those.

If you wish that it should not keep going and instead should stop, then I will replace line 889 in bin/Lipidyn with _exit(1)_ 