### PR TITLE
np.int renamed

### DIFF
--- a/LipidDyn/core.py
+++ b/LipidDyn/core.py
@@ -450,7 +450,7 @@ class Density:
             m2[m2 <  0.0 ] += 1.0
             m2 *= self.n2
 
-            grid_coords = np.array([m1, m2], dtype=np.int)
+            grid_coords = np.array([m1, m2], dtype=np.int64)
 
             np.add.at(grid, tuple(grid_coords), invcellvol)
         l_grids.append(grid) 


### PR DESCRIPTION
Changed np.int class to "np.int64" (LipidDyn/core.py), as "np.int" is deprecated and removed in the newest numpy version.