### PR TITLE
41 Order parameter improvements

### DIFF
--- a/LipidDyn/core.py
+++ b/LipidDyn/core.py
@@ -66,7 +66,7 @@ class OrderParameter:
     #             of the OP (when reading-in an already calculated result)
     
 
-    def __init__(self, name, resname, atom_A_name, atom_B_name, *args):
+    def __init__(self, name, resname, atom_A_name, atom_B_name):
         
         """Initialization of an instance of this class.
         Parameters
@@ -95,20 +95,6 @@ class OrderParameter:
         
         # Trajectory as list
         self.traj = []  # for storing OPs
-        
-        
-        # extra optional arguments allow setting avg,std values -- suitable for reading-in results of this script
-        if len(args) == 2:
-            self.avg = args[0]
-            self.std = args[1]
-        elif len(args) == 3:
-            self.avg  = args[0]
-            self.std  = args[1]
-            self.stem = args[2]
-        else:
-            if len(args) != 0:
-                logging.warning("Number of optional positional arguments is {len}, \
-                    not 3, 2 or 0. Args: {args}\n Wrong file format?".format(len=len(args), args=args))
 
 
     def calc_OP(self, atoms):
@@ -116,7 +102,6 @@ class OrderParameter:
         # Calculates Order Parameter according to equation
         # S = 1/2 * (3*cos(theta)^2 -1)
 
-        
         vec = atoms[1].position - atoms[0].position
         d2 = np.square(vec).sum()
         
@@ -124,17 +109,15 @@ class OrderParameter:
             logging.warning("Atomic distance for atoms \
                 {at1} and {at2} in residue no. {resnr} is suspiciously \
                 long: {d}!\nPBC removed???".format(at1=atoms[0].name, \
-                at2=atoms[1].name, resnr=atoms[0].resid, d=math.sqrt(d2)
-                )
-                )             
+                at2=atoms[1].name, resnr=atoms[0].resid, d=math.sqrt(d2)))
         
         cos2 = vec[2]**2/d2
         S = 0.5*(3.0*cos2-1.0)
         
-        return(S)
+        return S
 
 
-    def calc_angle(self, atoms, z_dim = 45.0):
+    def calc_angle(self, atoms, z_dim=45.0):
         
         # Calculates the angle between the vector and z-axis in degrees
         # no PBC check!
@@ -157,28 +140,26 @@ class OrderParameter:
                 angle = math.degrees(math.acos(cos))
         return angle
 
-    @property
-    def get_avg_std_OP(self):
+
+    # def get_avg_std_OP(self):
         
-        # Provides average and stddev of all OPs in self.traj
-        # This method becomes deprecated after the introduction of 
-        # error estimation
+    #     # Provides average and stddev of all OPs in self.traj
+    #     # This method becomes deprecated after the introduction of 
+    #     # error estimation
         
-        # convert to numpy array
-        return(np.mean(self.traj), np.std(self.traj))
+    #     # convert to numpy array
+    #     return(np.mean(self.traj), np.std(self.traj))
 
 
-    @property
     def get_avg_std_stem_OP(self):
         
         # Provides average, stddev and standard error of mean for 
         # all OPs in self.traj
         
         self.means = np.mean(self.traj, axis=0) # mean over frames
-        #print(len(self.means))  #means contain the mean of each residue
-        return( np.mean(self.traj), 
+        return (np.mean(self.traj), 
                  np.std(self.means), 
-                 np.std(self.means)/np.sqrt(len(self.means)) )  
+                 np.std(self.means)/np.sqrt(len(self.means)))
 
 
 def get_OP_cg(u,lipid_dict,lipid_name, sn):

--- a/LipidDyn/core.py
+++ b/LipidDyn/core.py
@@ -61,40 +61,63 @@ class OrderParameter:
     #    - name of the OP
     #    - residue name
     #    - involved atoms (exactly 2)
-    #    + extra: mean, std.dev. & err. estimate 
-    #             (using standard error of the means from individual residues)
-    #             of the OP (when reading-in an already calculated result)
     
 
-    def __init__(self, name, resname, atom_A_name, atom_B_name):
+    def __init__(self, u, name, resname, atAname, atBname):
         
-        """Initialization of an instance of this class.
+        """
+        Initialization of an instance of this class.
         Parameters
         ----------
+        u : mda.Universe instance
+                universe to perform selection of the atoms below
         name : str 
                 Name of the order parameter, a label
         resname : str
                 Name of residue atoms are in
-        atom_A_name : str
-                XXX
-        atom_B_name : str
-                XXX
+        atAname : str
+                Name of the first atom from the definition file
+        atBname : str
+                Name of the second atom from the definition file
 
         """
 
         self.name = name             # Name of the order parameter, a label
         self.resname = resname       # Name of residue atoms are in
-        self.atAname = atom_A_name
-        self.atBname = atom_B_name
-
-        # variables for error estimate -- standard error of the mean (STEM)
-        self.avg   = None   # average/mean value from all residues
-        self.means = None   # list of mean values from each individual residue
-        self.std   = None   # standard deviation (sqrt(variance))
-        self.stem  = None   # STandard Error of the Mean
+        self.atAname = atAname
+        self.atBname = atBname
         
-        # Trajectory as list
-        self.traj = []  # for storing OPs
+        # Trajectory list for storing OPs
+        self.traj = []
+
+        # Select atoms from the mda.universe
+        self.selection = self._select_atoms(u, resname, atAname, atBname)
+
+
+    def _select_atoms(self, u, resname, atAname, atBname):
+
+        '''
+        Internal function for the constructor. Returns mda.universe selection with
+        the provided atoms.
+        ----------
+        Returns : pairs of atoms selection, split-by residues
+        '''
+
+        # This selection format preserves the order of the atoms (atA, atB) independent of their order in the topology
+        selection = u.select_atoms("resname {rnm} and name {atA}".format(
+                                        rnm=resname, atA=atAname),
+                                     "resname {rnm} and name {atB}".format(
+                                        rnm=resname, atB=atBname)
+                                    ).atoms.split("residue")
+
+        # Sanity check for having only 2 atoms (A & B) selected
+        for res in selection:
+            if res.n_atoms != 2:
+                logging.warning("Selection >> name {atA} {atB} << \
+                contains {n_at} atoms, but should contain exactly 2!".format(
+                atA=atAname, atB=atBname, n_at=res.n_atoms))
+
+        return selection
 
 
     def calc_OP(self, atoms):
@@ -105,7 +128,7 @@ class OrderParameter:
         vec = atoms[1].position - atoms[0].position
         d2 = np.square(vec).sum()
         
-        if d2>bond_len_max_sq:
+        if d2 > bond_len_max_sq:
             logging.warning("Atomic distance for atoms \
                 {at1} and {at2} in residue no. {resnr} is suspiciously \
                 long: {d}!\nPBC removed???".format(at1=atoms[0].name, \
@@ -126,18 +149,18 @@ class OrderParameter:
         d = math.sqrt(np.square(vec).sum())
         cos = vec[2]/d
 
-        
         # values for the bottom leaflet are inverted so that 
         # they have the same nomenclature as the top leaflet
 
-        cos *= math.copysign(1.0, atoms[0].position[2]-z_dim*0.5)
+        cos *= math.copysign(1.0, atoms[0].position[2] - z_dim*0.5)
         try:
             angle = math.degrees(math.acos(cos))
         except ValueError:
-            if abs(cos)>=1.0:
+            if abs(cos) >= 1.0:
                 logging.debug("Cosine is too large = {} --> truncating it to +/-1.0".format(cos))
                 cos = math.copysign(1.0, cos)
                 angle = math.degrees(math.acos(cos))
+
         return angle
 
 
@@ -151,15 +174,13 @@ class OrderParameter:
     #     return(np.mean(self.traj), np.std(self.traj))
 
 
-    def get_avg_std_stem_OP(self):
+    def calc_avg_std_stem_OP(self):
         
-        # Provides average, stddev and standard error of mean for 
-        # all OPs in self.traj
-        
-        self.means = np.mean(self.traj, axis=0) # mean over frames
-        return (np.mean(self.traj), 
-                 np.std(self.means), 
-                 np.std(self.means)/np.sqrt(len(self.means)))
+        # Provides average, stddev and standard error of mean for all OPs in self.traj
+        self.means = np.mean(self.traj, axis=0)  # mean over frames
+        self.avg = np.mean(self.traj)
+        self.std = np.std(self.means)
+        self.stem = np.std(self.means)/np.sqrt(len(self.means))
 
 
 def get_OP_cg(u,lipid_dict,lipid_name, sn):
@@ -211,10 +232,11 @@ def get_OP_cg(u,lipid_dict,lipid_name, sn):
 
 def read_trajs_calc_OPs(u, ordPars):
     
-    """Procedure that creates MDAnalysis (mda) Universe instance 
-    with topology top,reads in trajectories trajs and then goes 
+    """
+    Procedure that reads in trajectories trajs and then goes 
     through every frame and evaluates each Order Parameter "S" 
-    from the list of OPs ordPars.
+    from the list of OPs ordPars. Finally providesaverage, stddev and
+    standard error of mean for all OPs in self.traj.
     Parameters
     ----------
     u : MDAnalysis.core.universe.Universe object 
@@ -223,31 +245,10 @@ def read_trajs_calc_OPs(u, ordPars):
         each item in this list describes an Order parameter to be calculated in the trajectory
     """
 
-    # make atom selections for each OP and store it as its attribute for later use with trajectory
+    # Go through trajectory frame-by-frame and calculate each OP
+    # from the list of OPs for each residue separately
     for op in ordPars.values():
-        # selection = pairs of atoms, split-by residues
-        # this selection format preserves the order of the atoms (atA, atB) independent of their order in the topology
-        selection = u.select_atoms("resname {rnm} and name {atA}".format(
-                                        rnm=op.resname, atA=op.atAname),
-                                     "resname {rnm} and name {atB}".format(
-                                        rnm=op.resname, atB=op.atBname)
-                                    ).atoms.split("residue")
-        
-        for res in selection:
-            # check if we have only 2 atoms (A & B) selected
-            if res.n_atoms != 2:
-                logging.warning("Selection >> name {atA} {atB} << \
-                contains {nat} atoms, but should contain exactly 2!".format(
-                atA=op.atAname, atB=op.atBname, nat=res.n_atoms)
-                )
-
-        op.selection = selection
-
-    # Go through trajectory frame-by-frame
-    # and calculate each OP from the list of OPs
-    # for each residue separately
-    for frame in u.trajectory:
-        for op in ordPars.values():
+        for frame in u.trajectory:
             
             # temporary list of order parameters for 
             # each individual residue for the given frame
@@ -263,26 +264,37 @@ def read_trajs_calc_OPs(u, ordPars):
             # resulting S-trajectory will be a list of lists
             # so that individual residues can be easily distinquished
             op.traj.append(temp_S)
+        
+        # calculate average, std dev and std error for the trajectory
+        # it is stored as attribute in each OrderParameter instance
+        op.calc_avg_std_stem_OP()
 
 
-def parse_op_input(def_file):
+def parse_op_input(u, def_file_path):
     
     """
-    parses input file with Order Parameter definitions
-    file format is as follows:
-    OP_name    resname    atom1    atom2  +extra: OP_mean  OP_std
-    (flexible cols)
-    fname : string
-        string 
+    Reads order parameter definition file to create OrderParameter instances
+    File format is as follows (ignores blank lines and lines starting by "#"):
+    OP_name    resname    atom1    atom2
+    
+    Parameters
+    ----------
+    u : mda.universe
+        universe instance of the system to make atom selection
+    def_file_path : string
+        path to the definition file
     returns : dictionary 
-        with OrderParameters class instances
+        with OrderParameters class instances, one for each arguments line in input file
     """
-    # Using ordered dict since it preserves the read-in order. Might come in handy when comparing to experiments.
+
+    # Using ordered dict since it preserves the read-in order. Might come in handy when comparing experiments.
     ordPars = OrderedDict()
-    for line in def_file:
-        if not line.startswith("#"):
-            items = line.split()
-            ordPars[items[0]] = OrderParameter(*items)
+    with open(def_file_path, 'r') as def_file:
+        for line in def_file:
+            if not line.startswith("#") and line.strip():
+                args = line.strip().split()
+                ordPars[args[0]] = OrderParameter(u, *args)
+
     return ordPars
 
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ the name of the enviroment is visible on the terminal
 
 Install numpy with:
 ```
-pip install numpy
+pip install numpy==1.23.5
 ```
 ```
 pip install packaging

--- a/README.md
+++ b/README.md
@@ -252,13 +252,13 @@ LipidDyn -f file.xtc/.trr -s file.gro -g file.yml -mov -n "n" -c
 5) Order Parameter calculation for each lipid category:
 ```
 LipidDyn -f file.xtc/.trr -s file.gro -g file.yml -op -n "n" -c
-
+```
 6) Membrane Curvature calculation for upper and lower leaflets:
 ```
 LipidDyn -f file.xtc/.trr -s file.gro -g file.yml -mc -n "n" -c
 
-
 ```
+
 ### Visualization of data
 
 For the visualization of the output data LipidDyn includes a set of tools for graphical representation.

--- a/bin/LipidDyn
+++ b/bin/LipidDyn
@@ -415,12 +415,8 @@ def module_movements(universe,
     pbar.finish()
 
 
-
-
 def module_order_parameter(u,
                            lipid_resnames,
-                           trajectory_file,
-                           topology_file,
                            parsed_yaml,
                            out_dir
                            ):
@@ -432,12 +428,6 @@ def module_order_parameter(u,
     
     lipid_resnames : list 
             Contains the lipid residue names
-
-    trajectory_file : str
-            Name of the processed .xtc file.
-    
-    topology_file : str
-            Name of the last producte .gro file.
     
     parsed_yaml : dict
             Contains the sn beads definition for
@@ -509,7 +499,7 @@ def module_order_parameter(u,
     elif parsed_yaml['forcefield'] == 'FA':
         
         # retrieve def file for the op in the package folder
-        dirs =  pkg_resources.resource_listdir('LipidDyn','/definitions_files/')
+        dirs = pkg_resources.resource_listdir('LipidDyn','/definitions_files/')
 
         pbar = ProgressBar().start()
         total_step = len(dirs)
@@ -525,9 +515,8 @@ def module_order_parameter(u,
             defi = list(filter(lambda x: x != '', defi)) # filter empty strings
             ordPars = parse_op_input(defi)
         
-            read_trajs_calc_OPs(ordPars,
-                                topology_file,
-                                [trajectory_file]
+            read_trajs_calc_OPs(u,
+                                ordPars
                                 )
 
             for op in ordPars.values():
@@ -546,6 +535,7 @@ def module_order_parameter(u,
                                 op.name, op.resname, op.atAname,
                                 op.atBname,op.avg, op.std, op.stem)
                             )
+                    
             except:
                 logging.warning("Problem writing the main outputfile")
 
@@ -1074,8 +1064,6 @@ def main():
         logging.info("Analysis: Order Parameter")
         module_order_parameter(u,
                                lipid_resnames,
-                               traj,
-                               topol,
                                parsed_yaml,
                                out_dir)
         logging.info("--------------------------------------")

--- a/bin/LipidDyn
+++ b/bin/LipidDyn
@@ -444,11 +444,10 @@ def module_order_parameter(u,
 
     if not os.path.exists(order_folder):
         try:
-            os.mkdir((order_folder))
+            os.mkdir(order_folder)
         except OSError as exc: # Guard against race condition
             if exc.errno != errno.EEXIST:
                 raise
-    
     
 
     # check if the system is CG from the config file    # ADD PBAR()
@@ -498,54 +497,46 @@ def module_order_parameter(u,
     # check if the system is FA from the config file
     elif parsed_yaml['forcefield'] == 'FA':
         
-        # retrieve def file for the op in the package folder
-        dirs = pkg_resources.resource_listdir('LipidDyn','/definitions_files/')
+        # retrieve def file names for the op in the package folder
+        def_file_names_all = pkg_resources.resource_listdir('LipidDyn', 'definitions_files')
+
+        # keep for analysis only those file names from residues present in the system
+        u_residues = set(f'{res}.def' for res in u.residues.groupby('resnames').keys())
+        def_file_names = u_residues.intersection(def_file_names_all)
+        if not def_file_names:
+            logging.info('No definition files found matching residues in system')
+        else:
+            logging.info('Performing order parameter analysis using definition files: ' + ', '.join(def_file_names))
 
         pbar = ProgressBar().start()
-        total_step = len(dirs)
+        total_step = len(def_file_names)
         step = 1
-        for def_file in dirs:
-
-            # get the lipid name
+        for def_file in def_file_names:
+            # get the lipid name from the file name
             lipid_name = def_file.split('.')[0]
-            # retrieve the def files from the package
-            defi = pkg_resources.resource_string('LipidDyn','/definitions_files/'+
-                                              def_file)
-            defi = defi.decode("utf-8").split('\n') # decode the strings from bytes
-            defi = list(filter(lambda x: x != '', defi)) # filter empty strings
-            ordPars = parse_op_input(defi)
-        
-            read_trajs_calc_OPs(u,
-                                ordPars
-                                )
 
-            for op in ordPars.values():
-                (op.avg, op.std, op.stem) = op.get_avg_std_stem_OP
+            # retrieve path to definition files
+            def_file_path = pkg_resources.resource_filename('LipidDyn', f'definitions_files/{def_file}')
 
+            # create dict ordPars with OrderParameter instances
+            ordPars = parse_op_input(u, def_file_path)
 
-            # writes the output file in  file
+            # calculate OPs through the trajectory and calculate average, std dev and std error
+            read_trajs_calc_OPs(u, ordPars)
+
+            # writes the output file for the lipid
             try:
-                with open('Order_Parameter_'+ lipid_name +'.csv',"w") as f:
-                    f.write("{},{},{},{},{},{},{}  \n".format(
+                with open(f'{order_folder}/Order_Parameter_{lipid_name}.csv', 'w') as out_file:
+                    out_file.write("{},{},{},{},{},{},{}\n".format(
                     'OP_name','resname','atom1','atom2','OP_mean','OP_stddev','OP_stem'))
                     for op in ordPars.values():
                         # output in csv file format comma separated
-                        f.write(
-                            "{},{},{},{},{: 2.5f},{: 2.5f},{: 2.5f} \n".format(
-                                op.name, op.resname, op.atAname,
-                                op.atBname,op.avg, op.std, op.stem)
-                            )
-                    
+                        out_file.write(
+                            "{},{},{},{},{: 2.5f},{: 2.5f},{: 2.5f}\n".format(
+                            op.name, op.resname, op.atAname,
+                            op.atBname, op.avg, op.std, op.stem))
             except:
-                logging.warning("Problem writing the main outputfile")
-
-
-            with open('Order_Parameter_'+ lipid_name +'.csv','r') as g :
-                if "nan" in g.read():
-                    os.remove('Order_Parameter_'+ lipid_name +'.csv')
-                else:
-                    shutil.move('Order_Parameter_'+ lipid_name +'.csv',
-                                order_folder)
+                logging.error(f'Problem writing output file for lipid {lipid_name}')
 
             pbar.update((step/total_step)*100)
             step += 1


### PR DESCRIPTION
The various improvements suggested in #41 were implemented for the order parameter analysis (full-atom part).
They include a reorganisation on the internal functions from LipidDyn/core.py and bin/LipidDyn.
The original code taken from https://github.com/NMRLipids/MATCH/blob/master/scripts/calcOrderParameters.py contained some features not needed in our program that made the code unclear.
Now the code is much more clear and the process is simplified in some points. The output remains unchanged (.csv with order parameters) as the technical parts have not been modified, but the messages for the .log file have been enhanced/removed when needed and small errors that produced warnings have been avoided.